### PR TITLE
Add type hints

### DIFF
--- a/hangulpy/chosung.py
+++ b/hangulpy/chosung.py
@@ -2,7 +2,7 @@
 
 from hangulpy.utils import CHOSUNG_LIST, CHOSUNG_BASE, is_hangul, HANGUL_BEGIN_UNICODE
 
-def get_chosung_string(text, keep_spaces=False):
+def get_chosung_string(text: str, keep_spaces: bool = False) -> str:
 	"""
 	주어진 문자열의 각 문자의 초성을 반환합니다.
 
@@ -22,7 +22,7 @@ def get_chosung_string(text, keep_spaces=False):
 	else:
 		return ''.join(extract_chosung(c) for c in text if is_hangul(c) or not c.isspace())
 
-def chosungIncludes(word, pattern):
+def chosungIncludes(word: str, pattern: str) -> bool:
 	"""
 	주어진 단어에 패턴의 초성이 포함되어 있는지 확인합니다.
 

--- a/hangulpy/hangul_check.py
+++ b/hangulpy/hangul_check.py
@@ -2,7 +2,7 @@
 
 from hangulpy.utils import CHOSUNG_LIST, JUNGSUNG_LIST
 
-def is_hangul_consonant(char):
+def is_hangul_consonant(char: str) -> bool:
 	"""
 	주어진 문자가 한글 자음인지 확인합니다.
 	
@@ -11,7 +11,7 @@ def is_hangul_consonant(char):
 	"""
 	return char in CHOSUNG_LIST
 
-def is_hangul_vowel(char):
+def is_hangul_vowel(char: str) -> bool:
 	"""
 	주어진 문자가 한글 모음인지 확인합니다.
 	

--- a/hangulpy/hangul_contains.py
+++ b/hangulpy/hangul_contains.py
@@ -3,7 +3,7 @@
 from hangulpy.utils import is_hangul
 from hangulpy.hangul_split import split_hangul_string
 
-def hangul_contains(word, pattern, notallowempty=False):
+def hangul_contains(word: str, pattern: str, notallowempty: bool = False) -> bool:
 	"""
 	주어진 한글 문자열이 다른 한글 문자열을 포함하는지 검사합니다.
 	

--- a/hangulpy/hangul_decompose.py
+++ b/hangulpy/hangul_decompose.py
@@ -1,12 +1,13 @@
 # hangul_decompose.py
 
 import warnings
+from typing import List, Tuple
 from hangulpy.utils import (
     CHOSUNG_LIST, CHOSUNG_BASE, is_hangul, HANGUL_BEGIN_UNICODE,
     JUNGSUNG_LIST, JUNGSUNG_DECOMPOSE, JONGSUNG_LIST, JONGSUNG_DECOMPOSE, JUNGSUNG_BASE
 )
 
-def decompose_hangul_string(s):
+def decompose_hangul_string(s: str) -> List[Tuple[str, Tuple[str, ...], Tuple[str, ...]]]:
     """
     주어진 문자열의 각 한글 음절을 초성, 중성, 종성으로 분해하여 배열 형태로 반환합니다.
 

--- a/hangulpy/hangul_ends_with_consonant.py
+++ b/hangulpy/hangul_ends_with_consonant.py
@@ -2,7 +2,7 @@
 
 from hangulpy.utils import is_hangul, HANGUL_BEGIN_UNICODE, CHOSUNG_LIST, JONGSUNG_LIST
 
-def ends_with_consonant(char):
+def ends_with_consonant(char: str) -> bool:
 	"""
 	주어진 문자가 자음으로 끝나는지 확인합니다.
 	

--- a/hangulpy/hangul_number.py
+++ b/hangulpy/hangul_number.py
@@ -1,8 +1,9 @@
 # hangul_number.py
 
+from typing import Union
 from hangulpy.utils import UNITS, NUMBERS
 
-def number_to_hangul(num):
+def number_to_hangul(num: Union[int, float]) -> str:
 	"""
 	주어진 숫자를 한글로 변환합니다.
 	
@@ -35,7 +36,7 @@ def number_to_hangul(num):
 	
 	return result
 
-def float_to_hangul(num):
+def float_to_hangul(num: float) -> str:
 	"""
 	주어진 소수를 한글로 변환합니다.
 	
@@ -45,7 +46,7 @@ def float_to_hangul(num):
 	int_part, frac_part = str(num).split('.')
 	return f"{number_to_hangul(int(int_part))} 점 {''.join(NUMBERS[int(d)] for d in frac_part)}"
 
-def hangul_to_number(hangul):
+def hangul_to_number(hangul: str) -> Union[int, float]:
 	"""
 	주어진 한글 숫자 문자열을 숫자로 변환합니다.
 	

--- a/hangulpy/hangul_role.py
+++ b/hangulpy/hangul_role.py
@@ -2,7 +2,7 @@
 
 from hangulpy.utils import CHOSUNG_LIST, JONGSUNG_LIST
 
-def can_be_chosung(char):
+def can_be_chosung(char: str) -> bool:
 	"""
 	주어진 문자가 한글 초성으로 쓰일 수 있는지 확인합니다.
 	
@@ -11,7 +11,7 @@ def can_be_chosung(char):
 	"""
 	return char in CHOSUNG_LIST
 
-def can_be_jongsung(char):
+def can_be_jongsung(char: str) -> bool:
 	"""
 	주어진 문자가 한글 종성으로 쓰일 수 있는지 확인합니다.
 	

--- a/hangulpy/hangul_sort.py
+++ b/hangulpy/hangul_sort.py
@@ -1,8 +1,9 @@
 # sort_hangul.py
 
+from typing import List
 from hangulpy.hangul_decompose import decompose_hangul_string
 
-def sort_hangul(words, reverse=False):
+def sort_hangul(words: List[str], reverse: bool = False) -> List[str]:
     """
     한글 문자열을 초성, 중성, 종성을 기준으로 정렬합니다.
     

--- a/hangulpy/hangul_split.py
+++ b/hangulpy/hangul_split.py
@@ -1,12 +1,13 @@
 # hangul_split.py
 
 import warnings
+from typing import List
 from hangulpy.utils import (
     CHOSUNG_LIST, CHOSUNG_BASE, is_hangul, HANGUL_BEGIN_UNICODE,
     JUNGSUNG_LIST, JUNGSUNG_DECOMPOSE, JONGSUNG_LIST, JONGSUNG_DECOMPOSE, JUNGSUNG_BASE
 )
 
-def split_hangul_string(s):
+def split_hangul_string(s: str) -> List[str]:
     """
     주어진 문자열의 각 한글 음절을 초성, 중성, 종성으로 분해하여 배열 형태로 반환합니다.
 

--- a/hangulpy/hangul_syllable.py
+++ b/hangulpy/hangul_syllable.py
@@ -2,7 +2,7 @@
 
 from hangulpy.utils import compose_syllable
 
-def hangul_syllable(cho, jung, jong=''):
+def hangul_syllable(cho: str, jung: str, jong: str = '') -> str:
     """
     입력된 초성, 중성, (선택적) 종성을 가지고 조합해 한글 문자를 만듭니다.
     

--- a/hangulpy/hangul_typoerror.py
+++ b/hangulpy/hangul_typoerror.py
@@ -1,13 +1,13 @@
 # hangul_typoerror.py
 
 from hangulpy.utils import (
-    CHOSUNG_LIST, JUNGSUNG_LIST, JONGSUNG_LIST, 
-    CONSONANT_MAP, VOWEL_MAP, CONSONANT_RMAP, VOWEL_RMAP, 
+    CHOSUNG_LIST, JUNGSUNG_LIST, JONGSUNG_LIST,
+    CONSONANT_MAP, VOWEL_MAP, CONSONANT_RMAP, VOWEL_RMAP,
     DOUBLE_INITIAL_MAP, COMPOUND_FINAL_MAP, COMPOUND_FINAL_DECOMP, VOWEL_COMBO,
     is_hangul, compose_syllable
 )
 
-def enko(eng_text, allowDoubleConsonant=False):
+def enko(eng_text: str, allowDoubleConsonant: bool = False) -> str:
     """
     영문 키보드 입력값을 한글 자모 조합으로 변환합니다.
     
@@ -98,7 +98,7 @@ def enko(eng_text, allowDoubleConsonant=False):
     flush()
     return "".join(result)
 
-def koen(kor_text):
+def koen(kor_text: str) -> str:
     """
     한글(자판 입력값)을 영문 키보드 입력값으로 변환합니다.
     
@@ -140,7 +140,7 @@ def koen(kor_text):
             result.append(ch)
     return "".join(result)
 
-def autofix(text, allowDoubleConsonant=False):
+def autofix(text: str, allowDoubleConsonant: bool = False) -> str:
     """
     입력 문자열의 각 구간(한글, 영문, 기타)을 분리하여
     한글인 부분은 koen, 영문인 부분은 enko를 적용합니다.

--- a/hangulpy/is_hangul.py
+++ b/hangulpy/is_hangul.py
@@ -2,7 +2,7 @@
 
 from hangulpy.utils import is_hangul as utils_is_hangul
 
-def is_hangul(text, spaces=False):
+def is_hangul(text: str, spaces: bool = False) -> bool:
     """
     입력된 값이 한글인지 확인합니다.
 

--- a/hangulpy/josa.py
+++ b/hangulpy/josa.py
@@ -2,10 +2,11 @@
 
 import re
 import unicodedata
+from typing import Optional
 from hangulpy.utils import is_hangul, HANGUL_BEGIN_UNICODE, JONGSUNG_COUNT
 from hangulpy import number_to_hangul
 
-def has_jongsung(char):
+def has_jongsung(char: str) -> bool:
     """
     주어진 한글 음절에 받침이 있는지 확인합니다.
     
@@ -19,7 +20,7 @@ def has_jongsung(char):
         return (char_index % JONGSUNG_COUNT) != 0
     return False
 
-def _get_last_valid_char(word):
+def _get_last_valid_char(word: str) -> Optional[str]:
     """
     문자열을 뒤에서부터 탐색하여 조사 판단에 사용할 가장 가까운 유효 문자를 반환합니다.
     유효 문자는 다음을 포함합니다:
@@ -59,7 +60,7 @@ def _get_last_valid_char(word):
         return None
     return None
 
-def josa(word, particle):
+def josa(word: str, particle: str) -> str:
     """
     주어진 단어에 적절한 조사를 붙여 반환합니다.
     

--- a/hangulpy/match_hangul_pattern.py
+++ b/hangulpy/match_hangul_pattern.py
@@ -1,7 +1,8 @@
 import re
+from typing import List
 from hangulpy.hangul_decompose import decompose_hangul_string
 
-def match_hangul_pattern(words, pattern):
+def match_hangul_pattern(words: List[str], pattern: str) -> List[str]:
     """
     주어진 단어 리스트에서 특정 초성, 중성, 종성 패턴에 매칭되는 단어를 찾습니다.
 

--- a/hangulpy/noun.py
+++ b/hangulpy/noun.py
@@ -3,7 +3,7 @@
 from hangulpy.utils import is_hangul, HANGUL_BEGIN_UNICODE, JONGSUNG_COUNT
 from hangulpy.josa import has_jongsung
 
-def jarip_noun(word, particle):
+def jarip_noun(word: str, particle: str) -> str:
     """
     주어진 단어에 적절한 자립명사를 붙여 반환합니다.
 

--- a/hangulpy/utils.py
+++ b/hangulpy/utils.py
@@ -2,6 +2,7 @@
 # ------------------------------------------------------------
 # 한글 유니코드 및 구성 요소 관련 상수, 리스트, 매핑 정보를 정의합니다.
 # ------------------------------------------------------------
+from typing import List, Tuple
 
 # [1] 한글 유니코드 범위 설정
 HANGUL_BEGIN_UNICODE = 0xAC00  # '가'
@@ -222,7 +223,8 @@ VOWEL_RMAP = {
 
 # [6] 한글 관련 함수들
 
-def is_hangul(text, spaces=False):
+
+def is_hangul(text: str, spaces: bool = False) -> bool:
     """
     입력된 문자열의 모든 문자가 한글 완성형(또는 띄어쓰기)인지 확인합니다.
     
@@ -240,7 +242,7 @@ def is_hangul(text, spaces=False):
             return False
     return True
 
-def compose_syllable(cho, jung, jong):
+def compose_syllable(cho: str, jung: str, jong: str) -> str:
     """
     초성, 중성, (선택적) 종성을 결합하여 완성형 한글 음절을 생성합니다.
     


### PR DESCRIPTION
## Summary
- add type hints across modules
- keep project compatible with Python 3.8

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*

------
https://chatgpt.com/codex/tasks/task_e_683f72f46e388329893202adbefef818